### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://z09620.visualstudio.com/655180d4-7a2b-40e3-b3c0-b4b8a39158bf/4b1fa0f7-d724-4526-ad7e-352786fe0f79/_apis/work/boardbadge/76be78c7-c2e8-4da3-bdfc-ffc6181ed5b6)](https://z09620.visualstudio.com/655180d4-7a2b-40e3-b3c0-b4b8a39158bf/_boards/board/t/4b1fa0f7-d724-4526-ad7e-352786fe0f79/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#14](https://z09620.visualstudio.com/655180d4-7a2b-40e3-b3c0-b4b8a39158bf/_workitems/edit/14). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.